### PR TITLE
Removing requirement on the 'sys' library

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -2,12 +2,10 @@
 var http = require('http'),
     path = require('path'),
     url = require('url'),
-    sys = require('sys'),
     request = require('request'),
     jQuery = require('jquery'),
     jsdom = require('jsdom'),
     Pool = require('generic-pool').Pool;
-
 
 exports.Crawler = function(options) {
     

--- a/test/selector.js
+++ b/test/selector.js
@@ -2,7 +2,6 @@
 QUnit.module("selector");
 
 var path = require( "path" ).normalize( __dirname + "/.." ),
-    sys = require("sys"),
     fs = require("fs"),
     Crawler = require(path + "/lib/crawler.js").Crawler;
 


### PR DESCRIPTION
The code is getting some deprecation warnings in the latest version of node (v0.6.8), specifically:

"The "sys" module is now called "util". It should have a similar interface."

After looking through the code, the "sys" util isn't being used, and after removing it, the tests passed.
